### PR TITLE
feat: Add white border to logo in QR code

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -20,7 +20,8 @@ function updateQRCode() {
       crossOrigin: "anonymous",
       imageSize: logoSize,
       hideBackgroundDots: false,
-      margin: 0,
+      margin: 4,
+      imageBackgroundColor: "#ffffff",
       imageBackgroundShape: "circle"
     },
     dotsOptions: {


### PR DESCRIPTION
This commit introduces a white border around the logo in the QR code.

The border is achieved by adding a margin to the image options and setting a white background color for the image. This ensures the border is always white, regardless of the QR code's background color.